### PR TITLE
Move conditional evaluation inside the tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Below we setup the Keen service using the slow request tracker:
     config.extra_attributes = { app: 'My-App' }
     config.logger = Rails.logger
     config.trackers = %i(slow_request)
+    block = -> { ENV['SOME_ENVIRONMENT_VARIABLE'] == 'production' }
+    config.conditionals = { slow_request: block }
     config.thresholds = { slow_request: 1_000 }
   end
 ```

--- a/lib/metrics_adapter/adapters/mixpanel.rb
+++ b/lib/metrics_adapter/adapters/mixpanel.rb
@@ -1,7 +1,7 @@
 require 'mixpanel-ruby'
 
 class MetricsAdapter::Adapters::Mixpanel
-  attr_reader :tracker
+  attr_reader :tracker, :logger
 
   def initialize(options)
     @tracker = ::Mixpanel::Tracker.new(options.fetch(:secret))

--- a/lib/metrics_adapter/rails.rb
+++ b/lib/metrics_adapter/rails.rb
@@ -2,12 +2,7 @@
 ##   1. Tracks slow request given a threshold
 ##
 ActiveSupport::Notifications.subscribe('process_action.action_controller') do |event|
-  trackers = MetricsAdapter.trackers
-  conditional = MetricsAdapter.conditionals[:slow_request]
-
-  if conditional.present? && conditional.call.blank?
-    Rails.logger.info('Metrics Adapter wont publish slow request metric.')
-  else
-    MetricsAdapter::Trackers::SlowRequest.new(event).call if trackers.include?(:slow_request)
+  if MetricsAdapter.trackers.include?(:slow_request)
+    MetricsAdapter::Trackers::SlowRequest.new(event).call
   end
 end

--- a/lib/metrics_adapter/trackers/base.rb
+++ b/lib/metrics_adapter/trackers/base.rb
@@ -2,6 +2,7 @@ module MetricsAdapter
   module Trackers
     class Base
       attr_reader :adapter,
+                  :conditional,
                   :event,
                   :extra_attributes,
                   :logger,
@@ -16,6 +17,7 @@ module MetricsAdapter
         @extra_attributes = ::MetricsAdapter.extra_attributes
         @logger = ::MetricsAdapter.logger
         @metric_name = self.class.name.demodulize.underscore
+        @conditional = ::MetricsAdapter.conditionals[@metric_name.to_sym]
       end
 
       def call

--- a/lib/metrics_adapter/trackers/slow_request.rb
+++ b/lib/metrics_adapter/trackers/slow_request.rb
@@ -9,6 +9,8 @@ module MetricsAdapter
       end
 
       def call
+        return if conditional.present? && conditional.call.blank?
+
         if event.duration > slow_request_threshold
           data = {
             id: event.transaction_id,
@@ -19,6 +21,9 @@ module MetricsAdapter
             idle_time_in_ms: event.idle_time,
             path: event.payload[:path]
           }.merge(extra_attributes)
+          logger.info(
+            "Slow request detected. Sending data to #{adapter.class.name}"
+          ) if logger
           adapter.publish(data)
         end
       end

--- a/lib/metrics_adapter/version.rb
+++ b/lib/metrics_adapter/version.rb
@@ -1,3 +1,3 @@
 module MetricsAdapter
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/metrics_adapter.gemspec
+++ b/metrics_adapter.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'byebug'
 end

--- a/spec/metrics_adapter/trackers/slow_request_spec.rb
+++ b/spec/metrics_adapter/trackers/slow_request_spec.rb
@@ -43,5 +43,45 @@ RSpec.describe MetricsAdapter::Trackers::SlowRequest do
         slow_request.call
       end
     end
+
+    context 'when metrics condition is false' do
+      let(:event) do
+        double(duration: 100_000)
+      end
+
+      before do
+        allow(
+          ::MetricsAdapter
+        ).to receive(:conditionals).and_return(slow_request: -> { false })
+      end
+
+      it 'do not send any metrics' do
+        expect(slow_request.adapter).to_not receive(:publish)
+        slow_request.call
+      end
+    end
+
+    context 'when metrics condition is true' do
+      let(:event) do
+        double(
+          duration: 1100,
+          transaction_id: '111',
+          idle_time: 1099,
+          cpu_time: 1,
+          payload: { method: 'GET', path: '/' }
+        )
+      end
+
+      before do
+        allow(
+          ::MetricsAdapter
+        ).to receive(:conditionals).and_return(slow_request: -> { true })
+      end
+
+      it 'sends metrics' do
+        expect(slow_request.adapter).to receive(:publish)
+        slow_request.call
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

This PR addresses two problems:

1. Added a simple logging message when catching slow requests.

2. Make the conditional be evaluate inside o the trackers.

## Conditional

The conditional is a feature added in the gem

The subscription block on rails does not accept breaks either
return for evaluating conditions, which can make the conditional logic
weird, ambiguous removing it's clearer intent on the code design.

Move inside the tracker makes more sense also for unit testing.
This logic should be moved up when creating the second tracker