### PR TITLE
Update bundler

### DIFF
--- a/metrics_adapter.gemspec
+++ b/metrics_adapter.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixpanel-ruby'
   spec.add_dependency 'keen'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '>= 2.2.33'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'byebug'


### PR DESCRIPTION
Bump bundler to `2.2.33`

More info [here](https://github.com/ministryofjustice/metrics-adapter/security/dependabot/metrics_adapter.gemspec/bundler/open)